### PR TITLE
STORM-2917: Check the derecated config nimbus.host

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/utils/NimbusClient.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/NimbusClient.java
@@ -23,6 +23,8 @@ import java.security.Principal;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.apache.commons.lang.StringUtils;
 import org.apache.storm.Config;
 import org.apache.storm.generated.Nimbus;
 import org.apache.storm.generated.NimbusSummary;
@@ -131,7 +133,7 @@ public class NimbusClient extends ThriftClient {
         }
 
         List<String> seeds;
-        if (conf.containsKey(Config.NIMBUS_HOST)) {
+        if (conf.containsKey(Config.NIMBUS_HOST) && StringUtils.isNotBlank(conf.get(Config.NIMBUS_HOST).toString())) {
             LOG.warn("Using deprecated config {} for backward compatibility. Please update your storm.yaml so it only has config {}",
                      Config.NIMBUS_HOST, Config.NIMBUS_SEEDS);
             seeds = Lists.newArrayList(conf.get(Config.NIMBUS_HOST).toString());


### PR DESCRIPTION
There is a situation: the deployer wants to use the new nimbus config(nimbus.seeds), but still leave the blank deprecated config(nimbus.host) in storm.yaml. It will not work.

To avoid this, the program should at least check whether the deprecated config is blank.